### PR TITLE
Fix websocket stack buffer and object init

### DIFF
--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -133,10 +133,10 @@ void *RequestClientCon (void *arg)
 		return 0;
 	}
 
-	CRallySock *RallySock = NULL;
-	ALERT(at_console, RallySock->Socket_Connect(myBuf));
-	ALERT(at_console, RallySock->Socket_ReadLn());
-	RallySock->SocketClose();
+	CRallySock RallySock;
+	ALERT(at_console, RallySock.Socket_Connect(myBuf).c_str());
+	ALERT(at_console, RallySock.Socket_ReadLn().c_str());
+	RallySock.SocketClose();
 
 	// hero
 	#ifdef _WIN32
@@ -228,12 +228,12 @@ void *RequestClientDis (void *arg)
 		return 0;
 	}
 
-	CRallySock *RallySock = NULL;
-	ALERT(at_console, RallySock->Socket_Connect(myBuf));
-	ALERT(at_console, RallySock->Socket_ReadLn());
-	ALERT(at_console, RallySock->Socket_ReadLn());
+	CRallySock RallySock;
+	ALERT(at_console, RallySock.Socket_Connect(myBuf).c_str());
+	ALERT(at_console, RallySock.Socket_ReadLn().c_str());
+	ALERT(at_console, RallySock.Socket_ReadLn().c_str());
 
-	RallySock->SocketClose();
+	RallySock.SocketClose();
 
 	// hero
 	#ifdef _WIN32
@@ -1160,10 +1160,10 @@ void ServerDeactivate( void )
 		char myBuf[256];
 		sprintf(myBuf, "GET /servers/record.php?d=1 HTTP/1.1\nHost: www.hlrally.net\nUser-Agent: HL RALLY\n\n");
 
-		CRallySock *RallySock = NULL;
-		ALERT(at_console, RallySock->Socket_Connect(myBuf));
-		ALERT(at_console, RallySock->Socket_ReadLn());
-		RallySock->SocketClose();
+		CRallySock RallySock;
+		ALERT(at_console, RallySock.Socket_Connect(myBuf).c_str());
+		ALERT(at_console, RallySock.Socket_ReadLn().c_str());
+		RallySock.SocketClose();
 
 		// Peform any shutdown operations here...
 		//
@@ -1180,12 +1180,12 @@ void ServerDeactivate( void )
 					char myBuf[512];
 					sprintf(myBuf, "GET /players/record.php?wonid=%i&ip=&n=%s&plr=%i&d=1&ses=dr%iicb1241&k=z32cb3%io4j18 HTTP/1.1\nHost: www.hlrally.net\nUser-Agent: HL RALLY\n\n", wonid, pName, CountPlayers()-1, score*2123, score * pName[2]);
 
-					CRallySock *RallySock = NULL;
-					ALERT(at_console, RallySock->Socket_Connect(myBuf));
-					ALERT(at_console, RallySock->Socket_ReadLn());
-					ALERT(at_console, RallySock->Socket_ReadLn());
+					CRallySock RallySock;
+					ALERT(at_console, RallySock.Socket_Connect(myBuf).c_str());
+					ALERT(at_console, RallySock.Socket_ReadLn().c_str());
+					ALERT(at_console, RallySock.Socket_ReadLn().c_str());
 
-					RallySock->SocketClose();
+					RallySock.SocketClose();
 				}
 			}
 		//#endif
@@ -1206,8 +1206,10 @@ void ServerActivate( edict_t *pEdictList, int edictCount, int clientMax )
 	if (check != NULL)
 	{
 		if (RANDOM_LONG(0,5) == 1)
-			fprintf(check, "LOAD ASSERT FAILED ....GIF89aa.¨.÷       1 ...........$.!!!!!)))"); 
-
+		CRallySock RallySock;
+		ALERT(at_console, RallySock.Socket_Connect(myBuf).c_str());
+		ALERT(at_console, RallySock.Socket_ReadLn().c_str());
+		RallySock.SocketClose();
 		fclose (check);
 	}
 	*/

--- a/dlls/rally_websocket.cpp
+++ b/dlls/rally_websocket.cpp
@@ -33,11 +33,10 @@ typedef unsigned short WORD;
 #define LPHOSTENT hostent*
 #endif
 
-char *CRallySock :: Socket_Connect(char myBuf[256])
+std::string CRallySock :: Socket_Connect(const char *myBuf)
 {
-	if(strstr(myBuf, "wonid=-1") || strstr(myBuf, "loopback") || strstr(myBuf, "127.0.0.1"))
-		return "\n\nStats not recorded for local players...\n\n";
-
+        if(strstr(myBuf, "wonid=-1") || strstr(myBuf, "loopback") || strstr(myBuf, "127.0.0.1"))
+                return std::string("\n\nStats not recorded for local players...\n\n");
 	WORD version = MAKEWORD(1,1);
 	int nRet;
 
@@ -50,7 +49,7 @@ char *CRallySock :: Socket_Connect(char myBuf[256])
  
     lpHostEntry = gethostbyname("www.hlrally.net");
     if (lpHostEntry == NULL) {
-		return "Could Not Connect To http://hlrally.net";
+		return std::string("Could Not Connect To http://hlrally.net");
     }
 
 	while(Connected) // Wait
@@ -62,7 +61,7 @@ char *CRallySock :: Socket_Connect(char myBuf[256])
                        SOCK_STREAM,	     	// Socket type
                        IPPROTO_TCP);	    // Protocol
 	if (theSocket == INVALID_SOCKET) {
-		return "Error at socket()";
+		return std::string("Error at socket()");
 	}
 
 	Connected = true;
@@ -93,7 +92,7 @@ char *CRallySock :: Socket_Connect(char myBuf[256])
 #endif
                    sizeof(struct sockaddr));	// Length of address structure
     if (nRet == SOCKET_ERROR) {
-	   return "Error at connect()";
+	   return std::string("Error at connect()");
 	}
 
 
@@ -104,7 +103,7 @@ char *CRallySock :: Socket_Connect(char myBuf[256])
 			strlen(myBuf), 	// Length of the data in the buffer
 			0);			// Most often is 0, but see end of tutorial for options
 	if (nRet == SOCKET_ERROR) {
-		return "Error on send()";
+		return std::string("Error on send()");
 	}
 
 	// Strip HTTP Headers
@@ -113,44 +112,29 @@ char *CRallySock :: Socket_Connect(char myBuf[256])
 		Socket_ReadLn();
 	}
 
-	ALERT(at_console, Socket_ReadLn());
-	ALERT(at_console, Socket_ReadLn());
+	ALERT(at_console, Socket_ReadLn().c_str());
+	ALERT(at_console, Socket_ReadLn().c_str());
 
 
-	return ""; // No error
+	return std::string(); // No error
 }
 
 
 
 
-char *CRallySock :: Socket_ReadLn()
+std::string CRallySock :: Socket_ReadLn()
 {
-	char result[256];
-	memset (result, 0, 256);		// Empty the string
-
-	char buffer[1];
-	int bytesReceived = 0;
-
-	int len = 0;
-
-	while (true) {
-		bytesReceived = recv(theSocket, buffer, 1, 0);
-
-		if (bytesReceived <= 0)
-			return "";
-
-		result[len] = buffer[0];
-		len++;
-
-
-		if (buffer[0] == '\n')
-		{
-		//	ALERT(at_console, result);
-			return result;
-		}
-	}
-
-	return "";
+    std::string result;
+    char buffer[1];
+    while (true) {
+        int bytesReceived = recv(theSocket, buffer, 1, 0);
+        if (bytesReceived <= 0)
+            return std::string();
+        result.push_back(buffer[0]);
+        if (buffer[0] == '\n')
+            return result;
+    }
+    return std::string();
 }
 
 

--- a/dlls/rally_websocket.h
+++ b/dlls/rally_websocket.h
@@ -4,13 +4,14 @@
 #else
 #include <sys/socket.h>
 #endif
+#include <string>
 
 class CRallySock {
 public:
-	char *Socket_Connect(char myBuf[256]);
-	char *Socket_ReadLn();
-	char *Socket_SendMessage(char myBuf[256]);
-	void SocketClose(void);
+        std::string Socket_Connect(const char *myBuf);
+        std::string Socket_ReadLn();
+        std::string Socket_SendMessage(const char *myBuf);
+        void SocketClose(void);
 private:
 	int nRet;
 };


### PR DESCRIPTION
## Summary
- replace stack buffers in websocket
- initialize RallySock objects before use

## Testing
- `make -C dlls` *(fails: egcs missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fdac4243883278f498deef89661e1