### PR TITLE
Fix encryption buffer allocation

### DIFF
--- a/dlls/Rally_CryptMessage.cpp
+++ b/dlls/Rally_CryptMessage.cpp
@@ -7,19 +7,28 @@
 #include "util.h"
 #include "cbase.h"
 
+
 #pragma warning(disable:4018)
 
-char * Encrypt(char *sName, char *data)
+// Returns a heap allocated buffer containing the encrypted message.  The caller
+// is responsible for freeing the returned pointer with delete[].
+char * Encrypt(const char *sName, const char *data)
 {
-	char *message = "";
+        if( !data )
+                return NULL;
 
-	int key = sName[1];
-	key = key / 10;
+        size_t len = strlen( data );
+        char *message = new char[len + 1];
+        message[len] = '\0';
 
-   	int step = 0, y;		// step for array handle
-    						// y for ASCII handler 
+        int key = 0;
+        if (sName && sName[1])
+                key = sName[1];
+        key = key / 10;
 
-	for (step = 0; step <= strlen(data); step++)
+        int y;                // ASCII handler
+
+        for (size_t step = 0; step < len; step++)
 	{
 		y = data[step];		//assign ASCII value
 

--- a/dlls/Rally_CryptMessage.h
+++ b/dlls/Rally_CryptMessage.h
@@ -5,7 +5,9 @@
 #ifndef _CryptMessage_H
 #define _CryptMessage_H
 
-extern char *Encrypt(char *sName, char *data);
+// Returns a heap allocated buffer containing the encrypted message. The caller
+// must free the returned pointer with delete[]
+extern char *Encrypt(const char *sName, const char *data);
 
 #endif
 


### PR DESCRIPTION
## Summary
- allocate writable buffer in `Encrypt`
- update header to match new signature

## Testing
- `make -j1` *(fails: `egcs` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdac47d20832792b3e2d40a5f58c5